### PR TITLE
'Kickstarting Flask on Ubuntu' link typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Resources
     - [Implementing a RESTful Web API with Python & Flask](http://blog.luisrei.com/articles/flaskrest.html)
     - [Discover Flask - Full Stack Web Development with Flask](http://discoverflask.com)
     - [Flaskr - Intro to Flask, Test Driven Development, and jQuery](https://github.com/mjhea0/flaskr-tdd)
-    - Kickstarting Flask on Ubuntu - Setup and Deployment](https://realpython.com/blog/python/kickstarting-flask-on-ubuntu-setup-and-deployment/)
+    - [Kickstarting Flask on Ubuntu - Setup and Deployment](https://realpython.com/blog/python/kickstarting-flask-on-ubuntu-setup-and-deployment/)
 - Books
     - [Explore Flask](http://exploreflask.com/)
     - [Flask Web Development](http://shop.oreilly.com/product/0636920031116.do)


### PR DESCRIPTION
Link title was missing left bracket [