### PR TITLE
Change Flask-WhooshAlchemy URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Plugins
 - i18n
     - [flask-babel](https://github.com/mitsuhiko/flask-babel) - i18n and l10n support for Flask based on Babel and pytz
 - Full-text searching
-    - [Flask-WhooshAlchemy](https://github.com/gyllstromk/Flask-WhooshAlchemy) - Whoosh indexing capabilities for Flask-SQLAlchemy
+    - [Flask-WhooshAlchemy](https://github.com/dhamaniasad/Flask-WhooshAlchemy) - Whoosh indexing capabilities for Flask-SQLAlchemy
 - Rate Limiting
     - [Flask-Limiter](https://github.com/alisaifee/flask-limiter) - Flask-Limiter provides rate limiting features to flask routes
 - Queue


### PR DESCRIPTION
The original Flask-WhooshAlchemy seems to have been abandoned, with the last update having been made almost a year ago. 
I've forked it and incorporated some of the pending pull requests and added Python 3 support. My fork has been on PyPI for a few months now. Maybe we could point to the forked version instead. 