### PR TITLE
Adds flask-ask to 'Framework'

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Plugins
 -------
 
 - Framework
+    - [Flask Ask](https://github.com/johnwheeler/flask-ask) - Rapid Alexa Skills Kit Development for Amazon Echo devices
     - [Flask Kit](https://github.com/semirook/flask-kit) - Flexible microkit for Flask microframework
     - [flask-peewee](https://github.com/coleifer/flask-peewee) - flask integration for peewee, including admin, authentication, rest api and more
     - [Flask-MongoRest](https://github.com/closeio/flask-mongorest) - Restful API framework wrapped around MongoEngine


### PR DESCRIPTION
Flask-Ask lowers the bar for developing Alexa Skills for Amazon Echo devices. It handles request signature verification and helps you organize your code with decorators and Jinja templates. Full Sphinx documentation and a decent README is available. Thank you for your consideration!