### PR TITLE
Adds flask-ask to 'Framework'

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Plugins
     - [Flask-RestPlus](https://github.com/noirbizarre/flask-restplus) - syntaxic sugar, helpers and automatically generated Swagger documentation on top of Flask-Restful.
     - [Flask-Potion](https://github.com/biosustain/potion) - RESTful API framework for Flask and SQLAlchemy
     - [enferno](https://github.com/level09/enferno) - A Flask-based Framework for the Next Decade
+    - [Flask-Ask](https://github.com/johnwheeler/flask-ask) - Rapid Alexa Skills Kit development for Amazon Echo devices
 - Admin
     - [Flask-Admin](https://github.com/flask-admin/flask-admin) - Simple and extensible administrative interface framework for Flask
     - [Flask-SuperAdmin](https://github.com/SyrusAkbary/Flask-SuperAdmin) - The best admin interface framework for Flask. With scaffolding for MongoEngine, Django and SQLAlchemy


### PR DESCRIPTION
Flask-Ask is an Amazon Echo development extension for Flask.

* Flask-Ask made front page on HackerNews Jun 10, 2016. Well received in comments. HackerNews https://news.ycombinator.com/item?id=11871554

* Flask-Ask made front page on Reddit's /r/Python. Not many comments. May 10, 2016. https://www.reddit.com/comments/4k972p

* Posted on Amazon Developer's blog https://developer.amazon.com/public/community/post/Tx14R0IYYGH3SKT/Flask-Ask-A-New-Python-Framework-for-Rapid-Alexa-Skills-Kit-Development

* Full Sphinx documentation for Flask-Ask is available at https://alexatutorial.com/flask-ask