### PR TITLE
added gREST to frameworks (under plugins category)

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Plugins
     - [enferno](https://github.com/level09/enferno) - A Flask-based Framework for the Next Decade
     - [Flasgger](https://github.com/rochacbruno/flasgger) - Create API documentation for Flask views using Swagger 2.0 specs
     - [flask-restful-swagger](https://github.com/rantav/flask-restful-swagger) - A wrapper for flask-restful which enables swagger support
+    - [gREST](https://github.com/mostafa/grest) - Build REST APIs with Neo4j and Flask, as quickly as possible!
 - Admin
     - [Flask-Admin](https://github.com/flask-admin/flask-admin) - Simple and extensible administrative interface framework for Flask
     - [Flask-SuperAdmin](https://github.com/SyrusAkbary/Flask-SuperAdmin) - The best admin interface framework for Flask. With scaffolding for MongoEngine, Django and SQLAlchemy


### PR DESCRIPTION
gREST (Graph-based REST API Framework) is a RESTful API development framework on top of Python, Flask, Neo4j and Neomodel. Its primary purpose is to ease development of RESTful APIs with little effort and miminum amount of code.