### PR TITLE
generalize link to PyVideo

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,8 +196,7 @@
 
 ## Videos
 
-- [Flask by Example](http://pyvideo.org/video/2608/flask-by-example/)
-- [Writing RESTful web services with Flask](http://pyvideo.org/video/2668/writing-restful-web-services-with-flask/)
+- [PyVideo](https://pyvideo.org/search.html?q=flask)
 - [Practical Flask Web Development Tutorials](https://www.youtube.com/playlist?list=PLQVvvaa0QuDc_owjTbIY4rbgXOFkUYOUB)
 
 ## Built with Flask


### PR DESCRIPTION
Since PyVideo will add new Flask videos all the time, it seems better to direct user to all Flask videos on PyVideo. If we listed all the good Flask videos from PyVideo, there would be too many, but with just a few we risk the videos aging out (the current PyVideo links from Grinberg are nearly 5 years old)