### PR TITLE
Add Quart to the list of Flask frameworks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@
 - [Flask-RestPlus](https://github.com/noirbizarre/flask-restplus) - syntaxic sugar, helpers and automatically generated Swagger documentation.
 - [Flask-Potion](https://github.com/biosustain/potion) - RESTful API framework for Flask and SQLAlchemy
 - [Zappa](https://github.com/Miserlou/Zappa) - Build and deploy server-less Flask applications on AWS Lambda and API Gateway
+- [Quart](https://gitlab.com/pgjones/quart) - A Python ASGI web microframework with the same API as Flask. Dealing with asyncio has never been that easy!
 
 ## Admin interface
 


### PR DESCRIPTION
Quart supports the full ASGI 3.0 specification as well as the websocket response and HTTP/2 server push extensions. For those of you familiar with Flask, Quart extends the Flask-API by adding support for:
- HTTP/1.1 request streaming.
- Websockets.
- HTTP/2 server push.

Quart is designed to be fully compatible with the Flask public API (aside from async and await keywords). Thereafter the aim is to be mostly compatible with the Flask private API and to provide no guarantees about the Werkzeug API.

Quart is very extendable and has a number of known [extensions](https://pgjones.gitlab.io/quart/quart_extensions.html) and works with many of the [Flask extensions](https://pgjones.gitlab.io/quart/flask_extensions.html).