### PR TITLE
Add Flask-PyMongo

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@
 
 - [Flask-MongoEngine](https://github.com/MongoEngine/flask-mongoengine) - MongoEngine flask extension with WTF model forms support
 - [Flask-SQLAlchemy](https://github.com/mitsuhiko/flask-sqlalchemy) - Adds SQLAlchemy support to Flask
+- [Flask-PyMongo](https://github.com/dcrosta/flask-pymongo) - PyMongo support for Flask applications
 
 ## Database Migrations
 


### PR DESCRIPTION
Flask-PyMongo is a useful flask extension which bridges Flask and PyMongo and provides some convenience helpers.