### PR TITLE
Add Flask-Static-Digest

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@
 - [flask-s3](https://github.com/e-dard/flask-s3) - Seamlessly serve your static assets of your Flask app from Amazon S3
 - [Flask-SSLify](https://github.com/kennethreitz/flask-sslify) - Force SSL on your Flask app
 - [Flask-HTMLmin](https://github.com/hamidfzm/Flask-HTMLmin) - Flask html minifier
+- [Flask-Static-Digest](https://github.com/nickjj/flask-static-digest) - Flask extension to help make your static files production ready by md5 tagging and gzipping them.
 
 ## Development (Debugging/Testing/Documentation)
 


### PR DESCRIPTION
Flask-Static-Digest is a Flask extension that will helps make static files production ready with very minimal effort.