### PR TITLE
Add Flask Admin Boilerplate with SMTP Relay and MongoDB integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,3 +250,4 @@
 - [flask-rest-template](https://github.com/alexandre/flask-rest-template)
 - [gae-init](https://gae-init.appspot.com) - Flask boilerplate running on Google App Engine
 - [Flask-AppBuilder](https://github.com/dpgaspar/Flask-AppBuilder) - Simple and rapid application builder framework, built on top of Flask. includes detailed security, auto form generation, google charts and much more
+- [Flask Admin Boilerplate](https://github.com/yorubadeveloper/flask-admin-boilerplate) - Flask Admin Dashboard boilerplate with SMTP Relay and MongoDB integrations.


### PR DESCRIPTION
This is a simple to use flask admin dashboard boilerplate made with SB Admin2 UI Elements and SMTP Relay using Flask-Mail and also MongoDB integration.