### PR TITLE
Add Simplehook

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@
 - [Flask-Gravatar](https://github.com/zzzsochi/Flask-Gravatar) - Small and simple gravatar usage in Flask
 - [Flask-Pusher](https://github.com/iurisilvio/Flask-Pusher) - Pusher integration for Flask
 - [Flask-Azure-Storage](https://github.com/alejoar/Flask-Azure-Storage) - Flask extension that provides integration with Azure Storage
+- [simplehook-flask](https://simplehook.dev/) - Receive webhooks at a stable URL in your Flask app with one line of code
 
 ## Frontend
 


### PR DESCRIPTION
## Summary

Adds [simplehook-flask](https://simplehook.dev/) to the **Other SDK** section.

Simplehook is a webhook delivery service for developers. The Flask integration (`pip install simplehook-flask`) lets you receive webhooks at a permanent, stable URL with one line of code — the URL stays the same across restarts, machines, and teammates, so there's no copy-pasting fresh tunnel URLs into dashboards every session. It also ships a Pull API for AI agents.

Free tier available. Source: https://github.com/bnbarak/antiwebhook

### Why it fits

The **Other SDK** section groups Flask extensions that wrap third-party services (Pusher, Azure Storage, Gravatar, GoogleMaps). `simplehook-flask` is the same kind of thing — a Flask-specific SDK for an external service.

### Diff

```diff
 - [Flask-Azure-Storage](https://github.com/alejoar/Flask-Azure-Storage) - Flask extension that provides integration with Azure Storage
+- [simplehook-flask](https://simplehook.dev/) - Receive webhooks at a stable URL in your Flask app with one line of code
```

Follows the format from `CONTRIBUTING.md` — `[RESOURCE](LINK) - DESCRIPTION`.